### PR TITLE
PackageManager: Avoid another NPE when dereferencing mPlatfromPackage

### DIFF
--- a/services/core/java/com/android/server/pm/PackageManagerService.java
+++ b/services/core/java/com/android/server/pm/PackageManagerService.java
@@ -13493,8 +13493,8 @@ public class PackageManagerService extends IPackageManager.Stub
         boolean allowed = (compareSignatures(
                 bp.packageSetting.signatures.mSignatures, pkg.mSignatures)
                         == PackageManager.SIGNATURE_MATCH)
-                || (compareSignatures(mPlatformPackage.mSignatures, pkg.mSignatures)
-                        == PackageManager.SIGNATURE_MATCH)
+                || (mPlatformPackage != null && compareSignatures(mPlatformPackage.mSignatures,
+                        pkg.mSignatures) == PackageManager.SIGNATURE_MATCH)
                 || (compareSignatures(mVendorPlatformSignatures, pkg.mSignatures)
                         == PackageManager.SIGNATURE_MATCH);
         if (!allowed && privilegedPermission) {


### PR DESCRIPTION
Change-Id: Idd989acb181b06f9c828fd740a9a20bfe6881bba