### PR TITLE
Fix SystemUI FC after disabling navbar and unlocking the phone

### DIFF
--- a/packages/SystemUI/src/com/android/systemui/statusbar/phone/StatusBar.java
+++ b/packages/SystemUI/src/com/android/systemui/statusbar/phone/StatusBar.java
@@ -5882,8 +5882,11 @@ public class StatusBar extends SystemUI implements DemoMode, TunerService.Tunabl
             if (forcedVisibility && mNavigationBarView == null) {
                 createNavigationBar();
             } else if (mNavigationBarView != null) {
+                FragmentHostManager fm = FragmentHostManager.get(mNavigationBarView);
                 mWindowManager.removeViewImmediate(mNavigationBarView);
                 mNavigationBarView = null;
+                fm.getFragmentManager().beginTransaction().remove(mNavigationBar).commit();
+                mNavigationBar = null;
             }
         } else if (BERRY_GLOBAL_STYLE.equals(key)) {
             updateTheme();


### PR DESCRIPTION
to replicate: boot with navbar enabled, then disable navbar, then switch
the screen off, then unlock with fingeprint or power button

java.lang.IllegalArgumentException: View=com.android.systemui.statusbar.phone.NavigationBarFrame{e0f4d97 G.E...... ......ID 0,0-1080,129 #7f0a01c4 app:id/navigation_bar_frame} not attached to window manager

Change-Id: I5ae631c129af28615d26754848915e351970e422