### PR TITLE
webkit: Add AOSP WebView provider by default

### DIFF
--- a/services/core/java/com/android/server/webkit/SystemImpl.java
+++ b/services/core/java/com/android/server/webkit/SystemImpl.java
@@ -80,6 +80,9 @@ public class SystemImpl implements SystemInterface {
         int numAvByDefaultAndNotFallback = 0;
         XmlResourceParser parser = null;
         List<WebViewProviderInfo> webViewProviders = new ArrayList<WebViewProviderInfo>();
+        WebViewProviderInfo aospProvider = new WebViewProviderInfo("com.android.webview",
+                "AOSP WebView", true, false, new String[0]);
+        webViewProviders.add(aospProvider);
         try {
             parser = AppGlobals.getInitialApplication().getResources().getXml(
                     com.android.internal.R.xml.config_webview_packages);
@@ -95,6 +98,9 @@ public class SystemImpl implements SystemInterface {
                     if (packageName == null) {
                         throw new AndroidRuntimeException(
                                 "WebView provider in framework resources missing package name");
+                    } else if (packageName.equals(aospProvider.packageName)) {
+                        // Ignore default AOSP provider, we already have it
+                        continue;
                     }
                     String description = parser.getAttributeValue(null, TAG_DESCRIPTION);
                     if (description == null) {


### PR DESCRIPTION
In our platform, AOSP WebView must be provided in all builds because users
might choose not to flash Google Apps (which otherwise would add Chrome
as a valid provider).

Some Treble devices override the XML configuration overlay in their
vendor partition without including the AOSP WebView provider.
Unfortunately, we have no other means of injecting it than adding it
by default as done in this commit.

Change-Id: I9fe567f2811f3651bb6e7c4ecb047b22907ebc12