### PR TITLE
NotificationManagerService: do not use flashing API for staying alway…

### DIFF
--- a/services/core/java/com/android/server/notification/NotificationManagerService.java
+++ b/services/core/java/com/android/server/notification/NotificationManagerService.java
@@ -5052,8 +5052,14 @@ public class NotificationManagerService extends SystemService {
             mNotificationLight.turnOff();
         } else {
             mNotificationLight.setModes(ledValues.getBrightness());
-            mNotificationLight.setFlashing(ledValues.getColor(), Light.LIGHT_FLASH_TIMED,
-                    ledValues.getOnMs(), ledValues.getOffMs());
+
+            // we are using 1:0 to indicate LED should stay always on
+            if (ledValues.getOnMs() == 1 && ledValues.getOffMs() == 0) {
+                mNotificationLight.setColor(ledValues.getColor());
+            } else {
+                mNotificationLight.setFlashing(ledValues.getColor(), Light.LIGHT_FLASH_TIMED,
+                        ledValues.getOnMs(), ledValues.getOffMs());
+            }
         }
     }
 


### PR DESCRIPTION
…s on

We allow to let the user set, that the notification light should stay
always on instead of flashing.

For that we are setting on duration to 1 and off duration to 0.
This can confuse some light HALs and/or kernel drivers.

Instead of using setFlashing, use setColor if duration is 1:0, like
we are already using for battery lights.

Change-Id: I4953592c72e0d095178757211dce2e206d8adb3c
Signed-off-by: Alexander Martinz <amartinz@shiftphones.com>