### PR TITLE
DO NOT MERGE - SUPL ES Extension - Safer Init and Not After Boot

### DIFF
--- a/location/java/com/android/internal/location/GpsNetInitiatedHandler.java
+++ b/location/java/com/android/internal/location/GpsNetInitiatedHandler.java
@@ -16,8 +16,6 @@
 
 package com.android.internal.location;
 
-import java.io.UnsupportedEncodingException;
-
 import android.app.Notification;
 import android.app.NotificationManager;
 import android.app.PendingIntent;
@@ -25,21 +23,21 @@ import android.content.BroadcastReceiver;
 import android.content.Context;
 import android.content.Intent;
 import android.content.IntentFilter;
-import android.location.LocationManager;
 import android.location.INetInitiatedListener;
-import android.telephony.TelephonyManager;
-import android.telephony.PhoneNumberUtils;
-import android.telephony.PhoneStateListener;
+import android.location.LocationManager;
 import android.os.Bundle;
 import android.os.RemoteException;
-import android.os.UserHandle;
 import android.os.SystemProperties;
+import android.os.UserHandle;
+import android.telephony.PhoneNumberUtils;
+import android.telephony.PhoneStateListener;
+import android.telephony.TelephonyManager;
 import android.util.Log;
-
-import com.android.internal.notification.SystemNotificationChannels;
 import com.android.internal.R;
+import com.android.internal.notification.SystemNotificationChannels;
 import com.android.internal.telephony.GsmAlphabet;
 import com.android.internal.telephony.TelephonyProperties;
+import java.io.UnsupportedEncodingException;
 
 /**
  * A GPS Network-initiated Handler class used by LocationManager.

--- a/services/core/java/com/android/server/location/GnssLocationProvider.java
+++ b/services/core/java/com/android/server/location/GnssLocationProvider.java
@@ -729,12 +729,11 @@ public class GnssLocationProvider implements LocationProviderInterface {
         // while IO initialization and registration is delegated to our internal handler
         // this approach is just fine because events are posted to our handler anyway
         mProperties = new Properties();
-        sendMessage(INITIALIZE_HANDLER, 0, null);
-
-        // Create a GPS net-initiated handler.
+        // Create a GPS net-initiated handler (also needed by handleInitialize)
         mNIHandler = new GpsNetInitiatedHandler(context,
                                                 mNetInitiatedListener,
                                                 mSuplEsEnabled);
+        sendMessage(INITIALIZE_HANDLER, 0, null);
 
         mListenerHelper = new GnssStatusListenerHelper(mHandler) {
             @Override


### PR DESCRIPTION
Safe order of pointer setting and background thread start
Verifying mCallEndElapsedRealtimeMillis is not the initial value

Bug: 112159033
Bug: 115361555
Bug: 125124724
Test: Verified not-after-boot with test code b/115361555#comment14
Test: Reproed NPE with test thread sleep and verify fix
Change-Id: Icd2ea91d71da71c8fda109ceb70514733d35060b
(cherry picked from commit a7cb82eb85cd361b90c9700ff935ba614c94f490)