### PR TITLE
HwBlob: s/malloc/calloc/

### DIFF
--- a/core/jni/android_os_HwBlob.cpp
+++ b/core/jni/android_os_HwBlob.cpp
@@ -84,7 +84,7 @@ JHwBlob::JHwBlob(JNIEnv *env, jobject thiz, size_t size)
       mOwnsBuffer(true),
       mHandle(0) {
     if (size > 0) {
-        mBuffer = malloc(size);
+        mBuffer = calloc(size, 1);
     }
 }
 


### PR DESCRIPTION
Since this blob is passed between processes.

We could potentially only memset portions of the blob as it is
written to. However, the JHwBlob API itself doesn't have to have
writes in order (even though known usages of it do write in order).
Because of this, keeping track of which bytes to pad would be too
expensive.

Bug: 131356202
Test: boot, hidl_test_java
Change-Id: I48f4d7cb20c4bfe747dd323ae3744d323ad097c9
Merged-In: I48f4d7cb20c4bfe747dd323ae3744d323ad097c9
(cherry picked from commit d8157bc094569bee74976df2585d632f1793e226)